### PR TITLE
Return response for delete method

### DIFF
--- a/src/Akamai/Akamai.php
+++ b/src/Akamai/Akamai.php
@@ -32,7 +32,7 @@ class Akamai extends NetStorage implements AkamaiInterface
 
     public function delete($url)
     {
-        $this->client->delete($url);
+        return $this->client->delete($url);
     }
 
     public function download($url)


### PR DESCRIPTION
When trying to use this API, it is important to be able to get the response for all of the actions. This simply returns the response for the delete method.
