### PR TITLE
Standardize return formats

### DIFF
--- a/Readme.MD
+++ b/Readme.MD
@@ -64,9 +64,9 @@ This method is to get the credentials in runtime.
 This method is used to upload a file to Akamai.
 
     /*
-        @param: $directory_path - The path in which the file has to be updated. ex: /cpcode/folder/path
-        @param: $body - Content of the file which has to be written.
-        @return: Array - Array has data and code variables.
+        @param: $akamai_path - File location with file name and extension to which the file should be uploaded. ex: /cpcode/folder/path/file.mp4
+        @param: $file_path - Path to the file to be written.
+        @return: Array - ["data" => API response, "code" => API response status code]
     */
 
 ###### 2) Akamai::dir($directory_path);
@@ -74,8 +74,8 @@ This method is used to upload a file to Akamai.
 This method is used to list the files in a particular directory.
 
     /*
-        @param: $directory_path - Directory path which has to be listed. ex: /cpcode/folder/path
-        @return: Array - Array has data and code variables.
+        @param: $akamai_path - Directory path to be listed. ex: /cpcode/folder/path
+        @return: Array - ["data" => API response, "code" => API response status code]
     */
 
 ###### 3) Akamai::download($file_path);
@@ -83,8 +83,8 @@ This method is used to list the files in a particular directory.
 This method is to download a file
 
     /*
-        @param: $file_path - File location with file name and extension. ex: /cpcode/folder/path/file.mp4.
-        @return: String - Content of the file.
+        @param: $akamai_path - File location with file name and extension. ex: /cpcode/folder/path/file.mp4.
+        @return: Array - ["data" => API response (contents of file on success), "code" => API response status code]
     */
 
 ###### 4) Akamai::delete($file_path);
@@ -92,8 +92,8 @@ This method is to download a file
 This method is to delete a file
 
     /*
-        @param: $file_path - File location with file name and extension. ex: /cpcode/folder/path/file.mp4.
-        @return: Array - Array has data and code variables.
+        @param: $akamai_path - File location with file name and extension. ex: /cpcode/folder/path/file.mp4.
+        @return: Array - ["data" => API response, "code" => API response status code]
     */
 
 ###### 5) Akamai::rmdir($directory_path);
@@ -101,8 +101,8 @@ This method is to delete a file
 This method is to delete a directory. [CAUTION: Directory has to be empty. (ie, list and delete all files individually before performing this API call)].
 
     /*
-        @param: $directory_path - Directory path which has to be deleted. ex: /cpcode/folder/path
-        @return: Array - Array has data and code variables.
+        @param: $akamai_path - Directory path to be deleted. ex: /cpcode/folder/path
+        @return: Array - ["data" => API response, "code" => API response status code]
     */
 
 ###### 6) Akamai::generateToken($duration, $type);

--- a/Readme.MD
+++ b/Readme.MD
@@ -57,6 +57,16 @@ This method is to get the credentials in runtime.
 #### 2) Akamai\Facades\Akamai
 ##### Introduction:
 `Akamai` facade is used to do the basic operations like upload, download etc.
+All API operations return responses as an array with fields for "data" and "code".
+
+    /*
+        [
+            "data" => API response (simple string or xml string),
+            "code" => API response status code
+        ]
+    */
+
+For a list of all possible status codes, see https://control.akamai.com/dl/customers/NS/NS_http_api_FS.pdf
 
 ##### Methods:
 ###### 1) Akamai::upload($directory_path, $body);
@@ -135,62 +145,69 @@ This method is to generate video authentication token.
 
         
 ### Usage sample
+```php
+<?php
 
-    <?php
+require_once __DIR__ . "/vendor/autoload.php";
 
-    require_once __DIR__ . "/vendor/autoload.php";
+use Akamai\Facades\Config;
+use Akamai\Facades\Akamai;
+use Akamai\Facades\Token;
 
-    use Akamai\Facades\Config;
-    use Akamai\Facades\Akamai;
-    use Akamai\Facades\Token;
+// For loading config info from different env file. Can be used to change credentials on run time. This method overwrites the existing config with latest one.
+Config::loadFromENV('./', '.akamai');
 
-    // For loading config info from different env file. Can be used to change credentials on run time. This method overwrites the existing config with latest one.
-    Config::loadFromENV('./', '.akamai');
+// Getting the akamai config in runtime
+$config = Config::getAkamaiConfig();
 
-    // Getting the akamai config in runtime
-    $config = Config::getAkamaiConfig();
+try {
+    /**
+     * @var array
+     * Example: [
+     *              "data" =>
+     *                  "<?xml version="1.0" encoding="ISO-8859-1"?>
+     *                      <stat directory="/cpcode/directory/path">
+     *                          <file type="file" name="filename.mp4" mtime="1234567890" size="1024" md5="f0qcf8xkl6y7p9mo5zror7bpmtiq392d"/>
+     *                      </stat>"
+     *               "code" => 200
+     *           ]
+     */
+    $dirResponse = Akamai::dir('/cpcode/directory/to/list');
 
-    try {
-        $xml = Akamai::dir('/cpcode/directory/to/list');
-        var_dump($xml);
-        /**
-            <?xml version="1.0" encoding="ISO-8859-1"?>
-                <stat directory="/cpcode/directory/path">
-                    <file type="file" name="filename.mp4" mtime="1234567890" size="1024" md5="f0qcf8xkl6y7p9mo5zror7bpmtiq392d"/>
-                </stat>
-        **/
+    /** @var array */
+    $uploadResponse = Akamai::upload('/cpcode/path/to/file/testing.mp4', './testing.mp4');
+    /** @var string */
+    $uploadResponeData = $uploadRespone["data"];
+    /** @var int */
+    $uploadResponseCode = $uploadResponse["code"];
 
-        $uploadResponse = Akamai::upload('/cpcode/path/to/file/testing.mp4', file_get_contents('./testing.mp4'));
-        var_dump($uploadResponse);
-        /**
-            ['data' => "could be string or xml",'code' => 200];
-        **/
-        
-        $filedata = Akamai::download('/cpcode/path/to/file/testing.mp4');
-        file_put_contents('./testing.mp4', $filedata);
-
-        $deleteResponse = Akamai::delete('/cpcode/path/to/file/testing.mp4');
-        var_dump($deleteResponse);
-        /**
-            ['data' => "could be string or xml",'code' => 200];
-        **/
-
-        $rmdirResponse = Akamai::rmdir('/cpcode/path/to/file/');
-        var_dump($rmdirResponse);
-        /**
-            ['data' => "could be string or xml",'code' => 200];
-        **/
-
-        $token = Token::generateVideoToken(100, "hdnts");
-        var_dump($token);
-        /**
-            hdnts=st=1470130755~exp=1470130855~acl=*~hmac=99665898830y435t37487889hl672055956t9p7455e14g765c056i413u433125;
-        **/
-
-    } catch (Exception $e) {
-        echo $e->getMessage();
+    /** @var array */
+    $downloadResponse = Akamai::download('/cpcode/path/to/file/testing.mp4');
+    if ($downloadReponse["code"] === 200) {
+        file_put_contents('./testing.mp4', $downloadResponse["data"]);
+    } else {
+        // perform some error handling based on status code
     }
 
+
+    /** @var array - ['data' => "could be simpel string or xml string",'code' => 200] */
+    $deleteResponse = Akamai::delete('/cpcode/path/to/file/testing.mp4');
+
+
+    /** @var array - ['data' => "could be simple string or xml string",'code' => 200] */
+    $rmdirResponse = Akamai::rmdir('/cpcode/path/to/file/');
+
+
+    $token = Token::generateVideoToken(100, "hdnts");
+    var_dump($token);
+    /**
+     * hdnts=st=1470130755~exp=1470130855~acl=*~hmac=99665898830y435t37487889hl672055956t9p7455e14g765c056i413u433125;
+     */
+
+} catch (Exception $e) {
+    echo $e->getMessage();
+}
+```
 
 ###Change Log:
 ####v2.0.0

--- a/src/Akamai/Akamai.php
+++ b/src/Akamai/Akamai.php
@@ -47,8 +47,7 @@ class Akamai extends NetStorage implements AkamaiInterface
 
     public function upload($filename, $raw_file_loc)
     {
-        $response = $this->client->upload($filename, $this->readFileData($raw_file_loc));
-        return $response;
+        return $this->client->upload($filename, $this->readFileData($raw_file_loc));
     }
 
     private function readFileData($filename)

--- a/src/Akamai/Services/NetStorage.php
+++ b/src/Akamai/Services/NetStorage.php
@@ -21,7 +21,6 @@ class NetStorage
     protected $version = 1;
 
     private $_http;
-    private $_last_status_code = null;
 
     protected function __construct()
     {
@@ -54,15 +53,9 @@ class NetStorage
         return $config;
     }
 
-    protected function getLastStatusCode()
-    {
-        return $this->_last_status_code;
-    }
-
     protected function upload($url, $body)
     {
-        $response_data = $this->_updateAction('upload', $url, array('body' => $body));
-        return ['data' => $response_data,'code' => $this->_last_status_code];
+        return $this->_updateAction('upload', $url, array('body' => $body));
     }
 
     protected function download($url)
@@ -100,7 +93,7 @@ class NetStorage
 
         $auth_data  = $this->auth->getAuthData();
         $auth_sign  = $this->auth->getAuthSign($url, $action_string);
-        
+
         $headers    = array(
             "Accept:",
             "Accept-Encoding: identity",
@@ -134,28 +127,26 @@ class NetStorage
 
     protected function rmdir($url)
     {
-        $response_data = $this->_updateAction('rmdir', $url);
-        return ['data' => $response_data,'code' => $this->_last_status_code];
+        return $this->_updateAction('rmdir', $url);
     }
 
     protected function delete($url)
     {
-        $response_data = $this->_updateAction('delete', $url);
-        return ['data' => $response_data,'code' => $this->_last_status_code];
+        return $this->_updateAction('delete', $url);
     }
 
     /**
      * quick_delete
      *
-         * Used to perform a “quick-delete” of a selected directory (including all of its contents).
+     * Used to perform a “quick-delete” of a selected directory (including all of its contents).
      * NOTE: The “quick-delete” action is disabled by default for security reasons, as it allows recursive
      *       removal of non-empty directory structures in a matter of seconds. If you wish to enable this feature,
-         *       please contact your Akamai Representative with the NetStorage CPCode(s) for which you wish to
-         *       use this feature.
+     *       please contact your Akamai Representative with the NetStorage CPCode(s) for which you wish to
+     *       use this feature.
      */
     protected function quickDelete($url, $qd_confirm)
     {
-        $this->_updateAction('quick-delete', $url, array('qd_confirm' => $qd_confirm));
+        return $this->_updateAction('quick-delete', $url, array('qd_confirm' => $qd_confirm));
     }
 
     private function _updateAction($action, $url, $options = array())
@@ -184,7 +175,7 @@ class NetStorage
 
         $auth_data  = $this->auth->getAuthData();
         $auth_sign  = $this->auth->getAuthSign($url, $action_string);
-        
+
         $headers    = array(
             "Accept:",
             "Accept-Encoding: identity",
@@ -222,11 +213,11 @@ class NetStorage
         }
 
         $data = curl_exec($curl);
-        $this->_last_status_code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+        $code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
         curl_close($curl);
         if ($tmpfile) { // Fix added from https://github.com/raben/Akamai/pull/4/files
             fclose($tmpfile); // Fix added from https://github.com/raben/Akamai/pull/4/files
         }
-        return $data;
+        return ["data" => $data, "code" => $code];
     }
 }


### PR DESCRIPTION
Addresses #2 
Copied from the commit message: 
An implementation detail worth noting is that I got rid of the notion
of last_status_code. It's only present use was for setting the 'code'
field in certain API actions. Saving that information to an instance
variable was unnecessary and when it's possible to avoid having state
in a service, I think it is good to do so.
