### PR TITLE
Fix timeout

### DIFF
--- a/src/Akamai/Services/AkamaiAuth.php
+++ b/src/Akamai/Services/AkamaiAuth.php
@@ -11,7 +11,6 @@ class AkamaiAuth
     public $key_name;
     public $client;
     public $server;
-    public $time;
     public $unique_id;
     public $version = 5;
 

--- a/src/Akamai/Services/AkamaiAuth.php
+++ b/src/Akamai/Services/AkamaiAuth.php
@@ -15,15 +15,12 @@ class AkamaiAuth
     public $unique_id;
     public $version = 5;
 
-    private $_data;
-
     public function __construct($key, $key_name, $version = 5)
     {
         $this->key = $key;
         $this->key_name = $key_name;
         $this->client   = '0.0.0.0';
         $this->server   = '0.0.0.0';
-        $this->time = time();
         $this->unique_id = mt_rand(1000000000, 9999999999);
         $this->version   = $version;
 
@@ -31,17 +28,14 @@ class AkamaiAuth
 
     public function getAuthData()
     {
-        if (!$this->_data) {
-            $this->_data = implode(', ', array(
-                $this->version,
-                $this->server,
-                $this->client,
-                $this->time,
-                $this->unique_id,
-                $this->key_name
-            ));
-        }
-        return $this->_data;
+        return implode(', ', array(
+            $this->version,
+            $this->server,
+            $this->client,
+            time(),
+            $this->unique_id,
+            $this->key_name
+        ));
     }
 
     public function getAuthSign($uri, $action)


### PR DESCRIPTION
From https://control.akamai.com/dl/customers/NS/NS_http_api_FS.pdf there is a line that reads:  

The time on a client using the API must be within one (1) minute of the actual
time. If the time varies more than this, then authentication will fail with an “HTTP
403” error.

Any script that runs longer than one minute will have API calls begin to fail when we cache the timestamp. This updates that